### PR TITLE
Add QuickItemGrabber - Grabs QQuickItem into QImage

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "qhttpserver/src/qhttpresponse.h"
 #include "qhttpserver/src/qhttpconnection.h"
 #include "documenthandler.h"
+#include "quickitemgrabber.h"
 #if USE_WEBENGINE
 #include <qtwebengineglobal.h>
 #endif
@@ -49,6 +50,7 @@ int main(int argc, char *argv[])
     QQmlApplicationEngine engine;
     engine.rootContext()->setContextProperty("platform", QVariant::fromValue(platformId));
     engine.rootContext()->setContextProperty("platformIP", QVariant::fromValue(platformIP));
+    engine.rootContext()->setContextProperty("Grabber",new QuickItemGrabber(&app));
     engine.load(QUrl("qrc:///main.qml"));
 #else
     QQuickView view;

--- a/src/quickitemgrabber.cpp
+++ b/src/quickitemgrabber.cpp
@@ -1,0 +1,191 @@
+/** Author:  Ben Lau (https://github.com/benlau)
+ */
+#include <QtGlobal>
+#include <QtCore>
+#include <QQuickWindow>
+#include <QOpenGLFunctions>
+#include "quickitemgrabber.h"
+
+#if (QT_VERSION < QT_VERSION_CHECK(5, 4, 0))
+#include <private/qquickitem_p.h>
+#include <private/qquickshadereffectsource_p.h>
+#else
+// Added since Qt 5.4
+#include <QQuickItemGrabResult>
+#endif
+
+
+QuickItemGrabber::QuickItemGrabber(QObject *parent) :
+    QObject(parent)
+{
+    m_busy = false;
+    m_ready = false;
+}
+
+bool QuickItemGrabber::busy() const
+{
+    return m_busy;
+}
+
+bool QuickItemGrabber::grab(QQuickItem *target,QSize targetSize)
+{
+    if (m_busy ||
+        target == 0  ||
+        !target->window() ||
+        !target->window()->isVisible() ) {
+        return false;
+    }
+    m_ready = false;
+    m_targetSize = targetSize;
+    m_target = target;
+    m_window = target->window();
+
+    if (m_targetSize.isEmpty()) {
+        m_targetSize = QSize(m_target->width(),m_target->height());
+    }
+
+#if (QT_VERSION < QT_VERSION_CHECK(5, 4, 0))
+
+    QQuickItemPrivate::get(m_target)->refFromEffectItem(false);
+
+    m_target->window()->update();
+
+    connect(m_window.data(),SIGNAL(beforeSynchronizing()),
+            this,SLOT(ready()),Qt::DirectConnection);
+
+    connect(m_window.data(),SIGNAL(afterRendering()),
+            this,SLOT(capture()),Qt::DirectConnection);
+#else
+
+    result = target->grabToImage(m_targetSize);
+
+    if (result.isNull()) {
+        qDebug() << "Can't grab target item";
+        return false;
+    }
+
+    connect(result.data(),SIGNAL(ready()),
+            this,SLOT(onGrabResultReady()));
+#endif
+
+    setBusy(true);
+
+    return true;
+}
+
+bool QuickItemGrabber::save(QString filename)
+{
+    if (m_image.isNull()) {
+        qWarning() << "QuickItemGrabber::save() - The image is null";
+        return false;
+    }
+    return m_image.save(filename);
+}
+
+void QuickItemGrabber::ready()
+{
+    m_ready = true;
+}
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
+void QuickItemGrabber::onGrabResultReady()
+{
+    QImage image =  result->image();
+    setImage(image);
+
+    result.clear();
+    setBusy(false);
+    emit grabbed();
+}
+#endif
+
+QImage QuickItemGrabber::image() const
+{
+    return m_image;
+}
+
+#if (QT_VERSION < QT_VERSION_CHECK(5, 4, 0))
+
+void QuickItemGrabber::capture()
+{
+    if (!m_ready) { // It is not ready yet
+        return;
+    }
+
+    if (m_target) { // Just in case the item is destroyed before rendering completed
+        QOpenGLContext* context = QOpenGLContext::currentContext();
+
+        QQuickShaderEffectTexture *m_texture = new QQuickShaderEffectTexture(m_target);
+        m_texture->setItem(QQuickItemPrivate::get(m_target)->itemNode());
+
+        // Set the source rectangle
+        QSize sourceSize;
+        sourceSize = QSize(m_target->width(),m_target->height());
+        m_texture->setRect(QRectF(0, sourceSize.height(), sourceSize.width(), -sourceSize.height()));
+
+        QSize maxSize = maxTextureSize();
+        /*
+        if (!maxSize.isValid()) {
+            GLint param;
+
+            QOpenGLFunctions glFuncs(context);
+            glFuncs.glGetIntegerv(GL_MAX_TEXTURE_SIZE,&param);
+
+            maxSize = QSize(param,param);
+            setMaxTextureSize(maxSize);
+        }
+
+        QSize textureSize = m_targetSize;
+        if (maxSize.isValid() &&
+                (textureSize.width() > maxSize.width() ||
+                textureSize.height() > maxSize.height())) {
+            FVRectToRect scaler;
+            scaler.scaleToFit(textureSize,maxSize);
+            // The required size is larger than max texture size.
+            qDebug() << "Downgrade target image from" << textureSize << scaler.transformedRect().toRect().size();
+            textureSize = scaler.transformedRect().toRect().size();
+        }
+        */
+
+        QSize expectedSize = textureSize();
+
+        QSGContext *sg = QSGRenderContext::from(context)->sceneGraphContext();
+        const QSize minSize = sg->minimumFBOSize();
+        m_texture->setSize(QSize(qMax<int>(minSize.width(), expectedSize.width()),
+                                  qMax<int>(minSize.height(), expectedSize.height())));
+        m_texture->scheduleUpdate();
+        m_texture->updateTexture();
+        QImage image =  m_texture->toImage();
+        setImage(image);
+
+        delete m_texture;
+        m_texture = 0;
+    }
+
+    disconnect(m_window.data(), SIGNAL(afterRendering()), this, SLOT(capture()));
+    disconnect(m_window.data(), SIGNAL(beforeSynchronizing()), this, SLOT(ready()));
+
+    setBusy(false);
+    emit grabbed();
+}
+#endif
+
+void QuickItemGrabber::setBusy(bool value)
+{
+    if (m_busy != value) {
+        m_busy = value;
+        emit busyChanged();
+    }
+}
+
+void QuickItemGrabber::setImage(QImage value)
+{
+    m_image = value;
+    emit imageChanged();
+}
+
+void QuickItemGrabber::clear()
+{
+    setImage(QImage());
+}
+

--- a/src/quickitemgrabber.h
+++ b/src/quickitemgrabber.h
@@ -1,0 +1,65 @@
+/** Author:  Ben Lau (https://github.com/benlau)
+ */
+#ifndef QUICKITEMGRABBER_H
+#define QUICKITEMGRABBER_H
+
+#include <QObject>
+#include <QQuickItem>
+#include <QImage>
+#include <QPointer>
+
+/// QuickItemGrabber grabs QQuickItem into QImage
+
+class QuickItemGrabber : public QObject
+{
+    Q_OBJECT
+    /// "Busy" flag. It is TRUE if the grabber is running. It won't accept another request when busy.
+    Q_PROPERTY(bool busy READ busy NOTIFY busyChanged)
+
+    /// The grabbed image
+    Q_PROPERTY(QImage image READ image NOTIFY imageChanged)
+
+public:
+    explicit QuickItemGrabber(QObject *parent = 0);
+
+    bool busy() const;
+    QImage image() const;
+
+    /// Grab the target item and save to "image" property
+    Q_INVOKABLE bool grab(QQuickItem* target,QSize targetSize = QSize());
+
+    /// Save the grabbed image into file. It is a blocked call.
+    Q_INVOKABLE bool save(QString filename);
+
+    /// Clear the captured image.
+    Q_INVOKABLE void clear();
+
+signals:
+    void busyChanged();
+    void imageChanged();
+    void grabbed();
+    void maxTextureSizeChanged();
+
+private:
+    // Ready for capture
+    Q_INVOKABLE void ready();
+
+#if (QT_VERSION < QT_VERSION_CHECK(5, 4, 0))
+    Q_INVOKABLE void capture();
+#else
+    Q_INVOKABLE void onGrabResultReady();
+    QSharedPointer<QQuickItemGrabResult> result;
+#endif
+
+    void setBusy(bool value);
+    void setImage(QImage value);
+
+    bool m_busy;
+    bool m_ready;
+    QSize m_targetSize;
+    QPointer<QQuickItem> m_target;
+    QPointer<QQuickWindow> m_window;
+    QImage m_image;
+};
+
+#endif // QUICKITEMGRABBER_H

--- a/terrarium-app.pro
+++ b/terrarium-app.pro
@@ -13,14 +13,16 @@ SOURCES += src/main.cpp \
     qhttpserver/src/qhttprequest.cpp \
     qhttpserver/src/qhttpresponse.cpp \
     qhttpserver/src/qhttpserver.cpp \
-    qhttpserver/http-parser/http_parser.c
+    qhttpserver/http-parser/http_parser.c \
+    src/quickitemgrabber.cpp
 
 HEADERS += qhttpserver/src/qhttpserver.h \
     qhttpserver/src//qhttpresponse.h \
     qhttpserver/src//qhttprequest.h \
     src/qmlhighlighter.h \
     src/documenthandler.h \
-    qhttpserver/src//qhttpconnection.h 
+    qhttpserver/src//qhttpconnection.h \ 
+    src/quickitemgrabber.h
 
 INCLUDEPATH += ./qhttpserver/http-parser/
 RESOURCES += qml/assets.qrc


### PR DESCRIPTION
It is patch to add a Grabber object into the programming environment so that user may grab their created item  into an image file.

Example code:

import QtQuick 2.0

Rectangle {    
    color : "white"

    Grid {
        id: icon
        anchors.centerIn: parent
        rows: 4
        columns : 4
        spacing : 0
	
        Repeater {
            model : ['#F44336',
                    '#E91E63',
                    '#9C27B0',
                    '#673AB7',
                    '#3F51B5',
                    '#2196F3',
                    '#03A9F4',
                    '#00BCD4',
                    '#009688',
                    '#4CAF50',
                    '#8BC34A',
                    '#CDDC39',
                    '#FFEB3B',
                    '#FFC107',
                    '#FF9800',
                    '#FF5722'
            ]
            delegate: Rectangle {
                width: 32
                height:32
                color : modelData
            }
        }
	
        
    }    
    

    Connections {
            target: Grabber
            onGrabbed:{
                Grabber.save("icon.png");
                Grabber.clear();
            }
    }

    MouseArea {
        anchors.fill: parent
        onClicked: Grabber.grab(icon);
    }

}
