### PR TITLE
Fix scrolling velocity that is inappropriate for trackpad

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -18,7 +18,7 @@ Window {
     property variant os_type: { '0': 'macx', '1': 'ios', '2': 'android', '3': 'linux', '4': 'default' }
     property variant platformSetting: {
         'ios': { 'lineNumberSpacing': -1, 'lineNumberPadding' : 20, 'defaultFont': 'Courier New' },
-        'macx': { 'lineNumberSpacing': -1, 'lineNumberPadding' : 20, 'defaultFont': 'Courier New' },
+        'macx': { 'lineNumberSpacing': -1, 'lineNumberPadding' : 20, 'defaultFont': 'Menlo' },
         'android': { 'lineNumberSpacing': 0, 'lineNumberPadding' : 20, 'defaultFont': 'Droid Sans Mono' },
         'linux': { 'lineNumberSpacing': 0, 'lineNumberPadding' : 20, 'defaultFont': 'Droid Sans Mono' },
         'default': { 'lineNumberSpacing': 0, 'lineNumberPadding' : 20, 'defaultFont': 'Droid Sans Mono' },
@@ -82,7 +82,7 @@ Window {
 
     NaviBar {
         state: "view"
-        id: navibar 
+        id: navibar
         z: 2
     }
 
@@ -184,8 +184,10 @@ Window {
         visible: opacity > 0 ? true : false
 
         Flickable {
+            id: flickable
             anchors { fill: parent; }
             flickableDirection: Flickable.VerticalFlick
+            boundsBehavior: Flickable.DragOverBounds
             contentWidth: parent.width
             contentHeight: editor.height
             clip: true


### PR DESCRIPTION
The default platform velocity for flickable would render Terrarium unusable on a Mac with a trackpad. One single tiny flick would send the text area out of bounds.

This patch fixes this, also changing the default font to cope with Terminal.app (this change could be discussed.)